### PR TITLE
Patch info redaction

### DIFF
--- a/dagbot/bot.py
+++ b/dagbot/bot.py
@@ -58,6 +58,7 @@ class Dagbot(commands.AutoShardedBot):
         self.session = None
         self.pool = None
         self.dagpi = None
+        self.repo = "https://github.com/Daggy1234/dagbot"
         self.caching = caching(self)
         self.bwordchecker = bword()
         self.bwordchecker.loadbword()

--- a/dagbot/extensions/misc.py
+++ b/dagbot/extensions/misc.py
@@ -449,13 +449,13 @@ class misc(commands.Cog):
                 channels += 1
         embed.add_field(
             name="Url's",
-            value="[Invite Link](https://discordapp.com/api/"
-                  "oauth2/authorize?client_id=675589737372975124"
-                  "&permissions=378944&scope=bot)\n"
-                  "[Support Server](https://discord.gg/grGkdeS)\n"
-                  "[API](https://dagpi.tk)\n"
-                  "[Website](https://dagbot.daggy.tech)\n"
-                  "[Source](https://github.com/Daggy1234/dagbot)",
+            value=f"[Invite Link](https://discordapp.com/api/"
+                  f"oauth2/authorize?client_id=675589737372975124"
+                  f"&permissions=378944&scope=bot)\n"
+                  f"[Support Server](https://discord.gg/grGkdeS)\n"
+                  f"[API](https://dagpi.tk)\n"
+                  f"[Website](https://dagbot.daggy.tech)\n"
+                  f"[Source]({self.bot.repo})",
             inline=True
         )
         embed.add_field(
@@ -505,22 +505,21 @@ class misc(commands.Cog):
 
         # This is inspired by R.danny source at
         # https://github.com/Rapptz/RoboDanny/blob/rewrite/cogs/meta.py#L328-L366
-        repo = "https://github.com/Daggy1234/dagbot"
         if command is None:
-            return await ctx.send(repo)
+            return await ctx.send(self.bot.repo)
         else:
             com = self.bot.get_command(command)
             if com is None:
                 return await ctx.send(
-                    'There is no command with that name. Maybe check repo\n'
-                    'https://github.com/Daggy1234/dagbot')
+                    f'There is no command with that name. Maybe check repo\n'
+                    f'{self.bot.repo}')
             else:
                 code = com.callback.__code__
                 filename = code.co_filename
                 lines, firstline = inspect.getsourcelines(code)
                 location = os.path.relpath(filename).replace('\\', '/')
-                final_url = f'{repo}/blob/master/{location}#L{firstline}-L' \
-                            f'{firstline + len(lines) - 1}'
+                final_url = (f'{self.bot.repo}/blob/master/{location}'
+                             f'#L{firstline}-L{firstline + len(lines) - 1}')
                 return await ctx.send(f"{final_url} is the source. Please follow the License used and don't forget to :star:")
 
 

--- a/dagbot/utils/context.py
+++ b/dagbot/utils/context.py
@@ -1,18 +1,14 @@
-from discord.embeds import Embed
 from discord.ext import commands
-from discord.ext.commands import context
 import discord
-import json
 
 
 class MyContext(commands.Context):
-
-    async def send(self, content=None, *, tts=False, embed: discord.Embed = None, file=None,
-                   files=None, delete_after=None, nonce=None,
-                   allowed_mentions=None):
+    async def send(self, content=None, *, tts=False,
+                   embed: discord.Embed = None, file=None, files=None,
+                   delete_after=None, nonce=None, allowed_mentions=None):
         bot = self.bot
 
-        if content:
+        if content and content.find(bot.repo) == -1:
             for key, val in bot.data.items():
                 content = content.replace(val, f"[ Omitted {key} ]")
         else:
@@ -21,18 +17,20 @@ class MyContext(commands.Context):
             desc = embed.description
             if desc:
                 for key, val in bot.data.items():
-                    if not key in ["imgflipuser", "database"]:
+                    if key not in ["imgflipuser", "database"]:
                         desc = desc.replace(val, f"[ Ommited {key}]")
                 embed.description = desc
             embed.color = self.guild.me.color
             if len(embed) > 2048:
-                return await super().send("This embed is a little too large to send.")
+                return await super().send("This embed is a little too large "
+                                          "to send.")
         if len(content) > 2000:
-            return await super().send("Little long there woul you like me to upload this?")
+            return await super().send("Little long there woul you like me to "
+                                      "upload this?")
 
-        else:
-            return await super().send(content, file=file, embed=embed, files=files, delete_after=delete_after, nonce=nonce,
-                                      allowed_mentions=allowed_mentions, tts=tts)
+        await super().send(content, file=file, embed=embed, files=files,
+                           delete_after=delete_after, nonce=nonce,
+                           allowed_mentions=allowed_mentions, tts=tts)
 
     async def safe_send(self, yes):
         await super().send("Yes this method is cool")


### PR DESCRIPTION
This PR attempts to fix a problem with redacting information in the custom context - when running the `send` command, the hyperlink ends up malformed due to the URL containing keywords that enforce redaction. Additionally, a very slight PEP8-compliant cleanup is now present alongside this change for 2 files (notably `dagbot/utils/context.py`, less so for `dagbot/extensions/misc.py`).

### Changes
- Assign the project repository URL as a bot variable to ensure global access
- Implement a check to ignore information redaction when the URL is present in the content provided
- Replace all usage instances of project repository URL with the new bot variable

### Unrelated
- Wrap a couple of lines to fit the 79 character limit
- Remove supposedly irrelevant else statement - unneecessary if both statements will return anyway, at least if the condition is met then the remaining function body is not executed otherwise the relevant message will be sent

### Note
Unrelated changes are welcome to be personally reverted despite their ability to improve code readability.